### PR TITLE
[DOCS] Correct typos and add Group=docker in systemd files

### DIFF
--- a/docs/docs/cluster/setup/controller.md
+++ b/docs/docs/cluster/setup/controller.md
@@ -396,6 +396,7 @@ Requires=docker.service
 
 [Service]
 User=drove
+Group=docker
 TimeoutStartSec=0
 Restart=always
 ExecStartPre=-/usr/bin/docker pull ghcr.io/phonepe/drove-controller:latest
@@ -434,7 +435,7 @@ systemctl enable drove.controller
 systemctl start drove.controller
 ```
 
-You can tail the logs at `/var/logs/drove/controller/drove-controller.log`.
+You can tail the logs at `/var/log/drove/controller/drove-controller.log`.
 
 The console would be available at `http://<ip>:10000` and admin functionality will be available on `http://<ip>:10001` according to the above config.
 

--- a/docs/docs/cluster/setup/executor-setup.md
+++ b/docs/docs/cluster/setup/executor-setup.md
@@ -451,6 +451,7 @@ Requires=docker.service
 
 [Service]
 User=drove
+Group=docker
 TimeoutStartSec=0
 Restart=always
 ExecStartPre=-/usr/bin/docker pull ghcr.io/phonepe/drove-executor:latest
@@ -489,6 +490,6 @@ systemctl enable drove.executor
 systemctl start drove.executor
 ```
 
-You can tail the logs at `/var/logs/drove/executor/drove-executor.log`.
+You can tail the logs at `/var/log/drove/executor/drove-executor.log`.
 
 The executor should now show up on the Drove Console.

--- a/docs/docs/cluster/setup/gateway.md
+++ b/docs/docs/cluster/setup/gateway.md
@@ -241,6 +241,7 @@ Requires=docker.service
 
 [Service]
 User=drove
+Group=docker
 TimeoutStartSec=0
 Restart=always
 ExecStartPre=-/usr/bin/docker pull ghcr.io/phonepe/drove-gateway:latest

--- a/docs/docs/cluster/setup/zookeeper.md
+++ b/docs/docs/cluster/setup/zookeeper.md
@@ -255,6 +255,7 @@ Requires=docker.service
 
 [Service]
 User=drove
+Group=docker
 TimeoutStartSec=0
 Restart=always
 ExecStartPre=-/usr/bin/docker pull zookeeper:3.8


### PR DESCRIPTION
Service configuration updates:

* [`docs/docs/cluster/setup/controller.md`](diffhunk://#diff-73815dcd1fd463159d9b97a12fd8b1eb49ab8725c02187f9bd63fb5471fbd270R399): Added `Group=docker` to the service configuration.
* [`docs/docs/cluster/setup/executor-setup.md`](diffhunk://#diff-80df5e139ecd08a392d7f80ae5d521ecb739c12333fada1f265bf5a9b90723feR454): Added `Group=docker` to the service configuration.
* [`docs/docs/cluster/setup/gateway.md`](diffhunk://#diff-ef884ea7de8fd9b306e7240e0bcab66d65b67e4cb4cbb8fc3b7a4af25c5f45b5R244): Added `Group=docker` to the service configuration.
* [`docs/docs/cluster/setup/zookeeper.md`](diffhunk://#diff-29d564fe5e1f7d654639dc79781e33e1c5f7149207044c276f4eef60282a33b3R258): Added `Group=docker` to the service configuration.

Log file path corrections:

* [`docs/docs/cluster/setup/controller.md`](diffhunk://#diff-73815dcd1fd463159d9b97a12fd8b1eb49ab8725c02187f9bd63fb5471fbd270L437-R438): Corrected log file path from `/var/logs/drove/controller/drove-controller.log` to `/var/log/drove/controller/drove-controller.log`.
* [`docs/docs/cluster/setup/executor-setup.md`](diffhunk://#diff-80df5e139ecd08a392d7f80ae5d521ecb739c12333fada1f265bf5a9b90723feL492-R493): Corrected log file path from `/var/logs/drove/executor/drove-executor.log` to `/var/log/drove/executor/drove-executor.log`.